### PR TITLE
feat(udb): add TIME_TRAVEL_UDB SQL clause for UDB recording

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: cmake-build-debug

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ scripts/__pycache__
 .claude/
 .codex/
 [Cc][Ll][Aa][Uu][Dd][Ee].md
+
+# Ignore env and direnv files
+.env
+.envrc
+.direnv/

--- a/nes-logical-operators/include/Operators/ReplayStoreLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/ReplayStoreLogicalOperator.hpp
@@ -39,10 +39,14 @@ public:
     ReplayStoreLogicalOperator() : ManagedByOperator(WeakLogicalOperator{}) { }
 
     explicit ReplayStoreLogicalOperator(WeakLogicalOperator self, DescriptorConfig::Config validatedConfig)
-        : ManagedByOperator(std::move(self)), config(std::move(validatedConfig)) { }
+        : ManagedByOperator(std::move(self)), config(std::move(validatedConfig))
+    {
+    }
 
     explicit ReplayStoreLogicalOperator(DescriptorConfig::Config validatedConfig)
-        : ManagedByOperator(WeakLogicalOperator{}), config(std::move(validatedConfig)) { }
+        : ManagedByOperator(WeakLogicalOperator{}), config(std::move(validatedConfig))
+    {
+    }
 
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId) const;
     [[nodiscard]] static std::string_view getName() noexcept;

--- a/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
@@ -1,0 +1,83 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <DataTypes/Schema.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+
+namespace NES
+{
+
+class UdbRecordingLogicalOperator
+{
+public:
+    UdbRecordingLogicalOperator() = default;
+
+    explicit UdbRecordingLogicalOperator(std::optional<std::string> traceName) : traceName(std::move(traceName)) { }
+
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId id) const;
+    [[nodiscard]] static std::string_view getName() noexcept;
+
+    [[nodiscard]] std::vector<LogicalOperator> getChildren() const;
+    [[nodiscard]] UdbRecordingLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] UdbRecordingLogicalOperator withTraitSet(TraitSet ts) const;
+    [[nodiscard]] TraitSet getTraitSet() const;
+    [[nodiscard]] bool operator==(const UdbRecordingLogicalOperator& rhs) const;
+
+    [[nodiscard]] std::vector<Schema> getInputSchemas() const;
+    [[nodiscard]] Schema getOutputSchema() const;
+    [[nodiscard]] UdbRecordingLogicalOperator withInferredSchema(std::vector<Schema> inputSchemas) const;
+
+    [[nodiscard]] const std::optional<std::string>& getTraceName() const { return traceName; }
+
+private:
+    static constexpr std::string_view NAME = "UdbRecording";
+    std::vector<LogicalOperator> children;
+    TraitSet traitSet;
+    std::optional<std::string> traceName;
+};
+
+template <>
+struct Reflector<UdbRecordingLogicalOperator>
+{
+    Reflected operator()(const UdbRecordingLogicalOperator& op) const;
+};
+
+template <>
+struct Unreflector<UdbRecordingLogicalOperator>
+{
+    UdbRecordingLogicalOperator operator()(const Reflected& reflected) const;
+};
+
+static_assert(LogicalOperatorConcept<UdbRecordingLogicalOperator>);
+
+}
+
+namespace NES::detail
+{
+struct ReflectedUdbRecordingLogicalOperator
+{
+    std::optional<std::string> traceName;
+};
+}

--- a/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <DataTypes/Schema.hpp>
@@ -55,7 +56,7 @@ public:
 
     [[nodiscard]] std::vector<Schema> getInputSchemas() const;
     [[nodiscard]] Schema getOutputSchema() const;
-    [[nodiscard]] UdbRecordingLogicalOperator withInferredSchema(std::vector<Schema> inputSchemas) const;
+    [[nodiscard]] UdbRecordingLogicalOperator withInferredSchema(const std::vector<Schema>&) const;
 
     [[nodiscard]] const std::optional<std::string>& getTraceName() const { return traceName; }
 

--- a/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
@@ -35,10 +35,14 @@ public:
     UdbRecordingLogicalOperator() : ManagedByOperator(WeakLogicalOperator{}) { }
 
     explicit UdbRecordingLogicalOperator(WeakLogicalOperator self, std::optional<std::string> traceName)
-        : ManagedByOperator(std::move(self)), traceName(std::move(traceName)) { }
+        : ManagedByOperator(std::move(self)), traceName(std::move(traceName))
+    {
+    }
 
     explicit UdbRecordingLogicalOperator(std::optional<std::string> traceName)
-        : ManagedByOperator(WeakLogicalOperator{}), traceName(std::move(traceName)) { }
+        : ManagedByOperator(WeakLogicalOperator{}), traceName(std::move(traceName))
+    {
+    }
 
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId id) const;
     [[nodiscard]] static std::string_view getName() noexcept;

--- a/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UdbRecordingLogicalOperator.hpp
@@ -29,12 +29,16 @@
 namespace NES
 {
 
-class UdbRecordingLogicalOperator
+class UdbRecordingLogicalOperator : public ManagedByOperator
 {
 public:
-    UdbRecordingLogicalOperator() = default;
+    UdbRecordingLogicalOperator() : ManagedByOperator(WeakLogicalOperator{}) { }
 
-    explicit UdbRecordingLogicalOperator(std::optional<std::string> traceName) : traceName(std::move(traceName)) { }
+    explicit UdbRecordingLogicalOperator(WeakLogicalOperator self, std::optional<std::string> traceName)
+        : ManagedByOperator(std::move(self)), traceName(std::move(traceName)) { }
+
+    explicit UdbRecordingLogicalOperator(std::optional<std::string> traceName)
+        : ManagedByOperator(WeakLogicalOperator{}), traceName(std::move(traceName)) { }
 
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId id) const;
     [[nodiscard]] static std::string_view getName() noexcept;
@@ -59,15 +63,15 @@ private:
 };
 
 template <>
-struct Reflector<UdbRecordingLogicalOperator>
+struct Reflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>
 {
-    Reflected operator()(const UdbRecordingLogicalOperator& op) const;
+    Reflected operator()(const TypedLogicalOperator<UdbRecordingLogicalOperator>& op) const;
 };
 
 template <>
-struct Unreflector<UdbRecordingLogicalOperator>
+struct Unreflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>
 {
-    UdbRecordingLogicalOperator operator()(const Reflected& reflected) const;
+    TypedLogicalOperator<UdbRecordingLogicalOperator> operator()(const Reflected& reflected, const ReflectionContext& context) const;
 };
 
 static_assert(LogicalOperatorConcept<UdbRecordingLogicalOperator>);

--- a/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -96,6 +97,7 @@ public:
         const LogicalPlan& queryPlan);
 
     static LogicalPlan addReplayStore(const DescriptorConfig::Config& config, const LogicalPlan& queryplan);
+    static LogicalPlan addUdbRecording(std::optional<std::string> traceName, const LogicalPlan& queryPlan);
     /// Checks in case a window is contained in the query.
     /// If a watermark operator exists in the queryPlan and if not adds a watermark strategy to the queryPlan.
     static LogicalPlan checkAndAddWatermarkAssigner(LogicalPlan queryPlan, const std::shared_ptr<Windowing::WindowType>& windowType);

--- a/nes-logical-operators/src/Operators/CMakeLists.txt
+++ b/nes-logical-operators/src/Operators/CMakeLists.txt
@@ -26,6 +26,7 @@ add_plugin(EventTimeWatermarkAssigner LogicalOperator EventTimeWatermarkAssigner
 add_plugin(InferModel LogicalOperator InferModelLogicalOperator.cpp)
 add_plugin(InferModelName LogicalOperator InferModelNameLogicalOperator.cpp)
 add_plugin(ReplayStore LogicalOperator ReplayStoreLogicalOperator.cpp)
+add_plugin(UdbRecording LogicalOperator UdbRecordingLogicalOperator.cpp)
 
 add_unreflection_plugin(LogicalOperator Selection)
 add_unreflection_plugin(LogicalOperator Projection)

--- a/nes-logical-operators/src/Operators/ReplayStoreLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ReplayStoreLogicalOperator.cpp
@@ -135,8 +135,8 @@ Reflector<TypedLogicalOperator<ReplayStoreLogicalOperator>>::operator()(const Ty
     return reflect(detail::ReflectedStoreLogicalOperator{.config = op->getConfig()});
 }
 
-TypedLogicalOperator<ReplayStoreLogicalOperator>
-Unreflector<TypedLogicalOperator<ReplayStoreLogicalOperator>>::operator()(const Reflected& reflected, const ReflectionContext& context) const
+TypedLogicalOperator<ReplayStoreLogicalOperator> Unreflector<TypedLogicalOperator<ReplayStoreLogicalOperator>>::operator()(
+    const Reflected& reflected, const ReflectionContext& context) const
 {
     auto [config] = context.unreflect<detail::ReflectedStoreLogicalOperator>(reflected);
     return TypedLogicalOperator<ReplayStoreLogicalOperator>{ReplayStoreLogicalOperator(std::move(config))};

--- a/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
@@ -1,0 +1,125 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Operators/UdbRecordingLogicalOperator.hpp>
+
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/Schema.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+#include <LogicalOperatorRegistry.hpp>
+
+namespace NES
+{
+
+std::string UdbRecordingLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId id) const
+{
+    if (verbosity == ExplainVerbosity::Debug)
+    {
+        return fmt::format("UDB_RECORDING(opId: {}, traceName: {})", id, traceName.value_or("<auto>"));
+    }
+    return {"UDB_RECORDING"};
+}
+
+std::string_view UdbRecordingLogicalOperator::getName() noexcept
+{
+    return NAME;
+}
+
+UdbRecordingLogicalOperator UdbRecordingLogicalOperator::withTraitSet(TraitSet ts) const
+{
+    auto copy = *this;
+    copy.traitSet = std::move(ts);
+    return copy;
+}
+
+TraitSet UdbRecordingLogicalOperator::getTraitSet() const
+{
+    return traitSet;
+}
+
+UdbRecordingLogicalOperator UdbRecordingLogicalOperator::withChildren(std::vector<LogicalOperator> newChildren) const
+{
+    auto copy = *this;
+    copy.children = std::move(newChildren);
+    return copy;
+}
+
+std::vector<LogicalOperator> UdbRecordingLogicalOperator::getChildren() const
+{
+    return children;
+}
+
+std::vector<Schema> UdbRecordingLogicalOperator::getInputSchemas() const
+{
+    INVARIANT(!children.empty(), "UdbRecording operator requires exactly one child");
+    return children | std::ranges::views::transform([](const LogicalOperator& child) { return child.getOutputSchema(); })
+        | std::ranges::to<std::vector>();
+}
+
+Schema UdbRecordingLogicalOperator::getOutputSchema() const
+{
+    INVARIANT(!children.empty(), "UdbRecording operator requires exactly one child");
+    return children.front().getOutputSchema();
+}
+
+UdbRecordingLogicalOperator UdbRecordingLogicalOperator::withInferredSchema(std::vector<Schema>) const
+{
+    auto copy = *this;
+    return copy;
+}
+
+bool UdbRecordingLogicalOperator::operator==(const UdbRecordingLogicalOperator& rhs) const
+{
+    return getOutputSchema() == rhs.getOutputSchema() && getTraitSet() == rhs.getTraitSet() && traceName == rhs.traceName;
+}
+
+}
+
+namespace NES
+{
+
+Reflected Reflector<UdbRecordingLogicalOperator>::operator()(const UdbRecordingLogicalOperator& op) const
+{
+    return reflect(detail::ReflectedUdbRecordingLogicalOperator{.traceName = op.getTraceName()});
+}
+
+UdbRecordingLogicalOperator Unreflector<UdbRecordingLogicalOperator>::operator()(const Reflected& reflected) const
+{
+    auto [traceName] = unreflect<detail::ReflectedUdbRecordingLogicalOperator>(reflected);
+    return UdbRecordingLogicalOperator(std::move(traceName));
+}
+
+LogicalOperatorRegistryReturnType
+LogicalOperatorGeneratedRegistrar::RegisterUdbRecordingLogicalOperator(LogicalOperatorRegistryArguments arguments)
+{
+    if (!arguments.reflected.isEmpty())
+    {
+        return unreflect<UdbRecordingLogicalOperator>(arguments.reflected);
+    }
+    PRECONDITION(false, "Operator is only built directly via parser or via reflection, not using the registry");
+    std::unreachable();
+}
+
+}

--- a/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
@@ -105,8 +105,8 @@ Reflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>::operator()(const T
     return reflect(detail::ReflectedUdbRecordingLogicalOperator{.traceName = op->getTraceName()});
 }
 
-TypedLogicalOperator<UdbRecordingLogicalOperator>
-Unreflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>::operator()(const Reflected& reflected, const ReflectionContext& context) const
+TypedLogicalOperator<UdbRecordingLogicalOperator> Unreflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>::operator()(
+    const Reflected& reflected, const ReflectionContext& context) const
 {
     auto [traceName] = context.unreflect<detail::ReflectedUdbRecordingLogicalOperator>(reflected);
     return TypedLogicalOperator<UdbRecordingLogicalOperator>{UdbRecordingLogicalOperator(std::move(traceName))};

--- a/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
@@ -84,9 +84,10 @@ Schema UdbRecordingLogicalOperator::getOutputSchema() const
     return children.front().getOutputSchema();
 }
 
-UdbRecordingLogicalOperator UdbRecordingLogicalOperator::withInferredSchema(std::vector<Schema>) const
+UdbRecordingLogicalOperator UdbRecordingLogicalOperator::withInferredSchema(const std::vector<Schema>&) const
 {
-    return *this;
+    auto copy = *this;
+    return copy;
 }
 
 bool UdbRecordingLogicalOperator::operator==(const UdbRecordingLogicalOperator& rhs) const

--- a/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
@@ -86,13 +86,12 @@ Schema UdbRecordingLogicalOperator::getOutputSchema() const
 
 UdbRecordingLogicalOperator UdbRecordingLogicalOperator::withInferredSchema(std::vector<Schema>) const
 {
-    auto copy = *this;
-    return copy;
+    return *this;
 }
 
 bool UdbRecordingLogicalOperator::operator==(const UdbRecordingLogicalOperator& rhs) const
 {
-    return getOutputSchema() == rhs.getOutputSchema() && getTraitSet() == rhs.getTraitSet() && traceName == rhs.traceName;
+    return traitSet == rhs.traitSet && traceName == rhs.traceName;
 }
 
 }

--- a/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UdbRecordingLogicalOperator.cpp
@@ -100,23 +100,26 @@ bool UdbRecordingLogicalOperator::operator==(const UdbRecordingLogicalOperator& 
 namespace NES
 {
 
-Reflected Reflector<UdbRecordingLogicalOperator>::operator()(const UdbRecordingLogicalOperator& op) const
+Reflected
+Reflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>::operator()(const TypedLogicalOperator<UdbRecordingLogicalOperator>& op) const
 {
-    return reflect(detail::ReflectedUdbRecordingLogicalOperator{.traceName = op.getTraceName()});
+    return reflect(detail::ReflectedUdbRecordingLogicalOperator{.traceName = op->getTraceName()});
 }
 
-UdbRecordingLogicalOperator Unreflector<UdbRecordingLogicalOperator>::operator()(const Reflected& reflected) const
+TypedLogicalOperator<UdbRecordingLogicalOperator>
+Unreflector<TypedLogicalOperator<UdbRecordingLogicalOperator>>::operator()(const Reflected& reflected, const ReflectionContext& context) const
 {
-    auto [traceName] = unreflect<detail::ReflectedUdbRecordingLogicalOperator>(reflected);
-    return UdbRecordingLogicalOperator(std::move(traceName));
+    auto [traceName] = context.unreflect<detail::ReflectedUdbRecordingLogicalOperator>(reflected);
+    return TypedLogicalOperator<UdbRecordingLogicalOperator>{UdbRecordingLogicalOperator(std::move(traceName))};
 }
 
+/// NOLINTNEXTLINE(performance-unnecessary-value-param)
 LogicalOperatorRegistryReturnType
 LogicalOperatorGeneratedRegistrar::RegisterUdbRecordingLogicalOperator(LogicalOperatorRegistryArguments arguments)
 {
     if (!arguments.reflected.isEmpty())
     {
-        return unreflect<UdbRecordingLogicalOperator>(arguments.reflected);
+        return ReflectionContext{}.unreflect<TypedLogicalOperator<UdbRecordingLogicalOperator>>(arguments.reflected);
     }
     PRECONDITION(false, "Operator is only built directly via parser or via reflection, not using the registry");
     std::unreachable();

--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -35,12 +35,12 @@
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/ReplayStoreLogicalOperator.hpp>
-#include <Operators/UdbRecordingLogicalOperator.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
 #include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Operators/Sources/InlineSourceLogicalOperator.hpp>
 #include <Operators/Sources/SourceNameLogicalOperator.hpp>
+#include <Operators/UdbRecordingLogicalOperator.hpp>
 #include <Operators/UnionLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>

--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -35,6 +35,7 @@
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/ReplayStoreLogicalOperator.hpp>
+#include <Operators/UdbRecordingLogicalOperator.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
 #include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
@@ -212,6 +213,11 @@ LogicalPlan LogicalPlanBuilder::addReplayStore(const DescriptorConfig::Config& c
 {
     const auto storeOp = ReplayStoreLogicalOperator(config);
     return promoteOperatorToRoot(queryPlan, storeOp);
+}
+
+LogicalPlan LogicalPlanBuilder::addUdbRecording(std::optional<std::string> traceName, const LogicalPlan& queryPlan)
+{
+    return promoteOperatorToRoot(queryPlan, UdbRecordingLogicalOperator(std::move(traceName)));
 }
 
 LogicalPlan

--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <string>
 #include <unordered_map>

--- a/nes-physical-operators/include/UdbRecordingPhysicalOperator.hpp
+++ b/nes-physical-operators/include/UdbRecordingPhysicalOperator.hpp
@@ -1,0 +1,52 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <Nautilus/Interface/Record.hpp>
+#include <Nautilus/Interface/RecordBuffer.hpp>
+#include <CompilationContext.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalOperator.hpp>
+
+namespace NES
+{
+
+/// Physical operator that spawns a udb recording process attached to the current NES process.
+/// Tuples pass through unchanged. The udb process is started once during pipeline setup
+/// and runs until NES terminates.
+class UdbRecordingPhysicalOperator final : public PhysicalOperatorConcept
+{
+public:
+    /// traceName is forwarded to udb as the output trace name (optional).
+    explicit UdbRecordingPhysicalOperator(std::optional<std::string> traceName);
+
+    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
+    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void execute(ExecutionContext& executionCtx, Record& record) const override;
+    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void terminate(ExecutionContext& executionCtx) const override;
+
+    [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
+    void setChild(PhysicalOperator child) override;
+
+private:
+    std::optional<std::string> traceName;
+    std::optional<PhysicalOperator> child;
+};
+
+}

--- a/nes-physical-operators/include/UdbRecordingPhysicalOperator.hpp
+++ b/nes-physical-operators/include/UdbRecordingPhysicalOperator.hpp
@@ -17,8 +17,8 @@
 #include <optional>
 #include <string>
 
-#include <Nautilus/Interface/Record.hpp>
-#include <Nautilus/Interface/RecordBuffer.hpp>
+#include <Interface/Record.hpp>
+#include <Interface/RecordBuffer.hpp>
 #include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>

--- a/nes-physical-operators/src/CMakeLists.txt
+++ b/nes-physical-operators/src/CMakeLists.txt
@@ -27,7 +27,8 @@ add_source_files(nes-physical-operators
         WindowBuildPhysicalOperator.cpp
         WindowProbePhysicalOperator.cpp
         ReplayStoreOperatorHandler.cpp
-        ReplayStorePhysicalOperator.cpp)
+        ReplayStorePhysicalOperator.cpp
+        UdbRecordingPhysicalOperator.cpp)
 
 add_subdirectory(Aggregation)
 add_subdirectory(Watermark)

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -15,11 +15,12 @@
 #include <UdbRecordingPhysicalOperator.hpp>
 
 #include <cstdlib>
-#include <fcntl.h>
 #include <optional>
 #include <string>
-#include <sys/wait.h>
+#include <fcntl.h>
 #include <unistd.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
 
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
@@ -49,7 +50,7 @@ void spawnUdbProxy(const char* traceName)
     const char* udbBin = std::getenv("UDB_BINARY_PATH");
     if (udbBin == nullptr)
     {
-        NES_WARNING("UDB_BINARY_PATH is not set — skipping udb recording");
+        NES_ERROR("UDB_BINARY_PATH is not set — skipping udb recording");
         return;
     }
 
@@ -77,9 +78,9 @@ void spawnUdbProxy(const char* traceName)
     {
         /// Child: write end is O_CLOEXEC — exec closes it. On failure write a byte so parent detects it.
         if (traceName != nullptr)
-            ::execlp(udbBin, udbBin, "--pid", pidBuf, "--recording-file", traceFileBuf, nullptr);
+            ::execl(udbBin, udbBin, "--pid", pidBuf, "--recording-file", traceFileBuf, nullptr);
         else
-            ::execlp(udbBin, udbBin, "--pid", pidBuf, nullptr);
+            ::execl(udbBin, udbBin, "--pid", pidBuf, nullptr);
 
         /// execlp only returns on failure — only async-signal-safe calls allowed here.
         const char errByte = 1;
@@ -97,6 +98,12 @@ void spawnUdbProxy(const char* traceName)
         return;
     }
 
+    /// Grant ptrace permission to exactly this child; avoids having to lower yama/ptrace_scope to 0 (c.f. man 2 prctl)
+    if (::prctl(PR_SET_PTRACER, static_cast<unsigned long>(child)) < 0)
+    {
+        NES_ERROR("UdbRecordingPhysicalOperator: prctl(PR_SET_PTRACER) failed, errno={}", errno);
+    }
+
     char result = 0;
     if (::read(pipeFd[0], &result, 1) == 1)
     {
@@ -108,8 +115,7 @@ void spawnUdbProxy(const char* traceName)
 
 }
 
-UdbRecordingPhysicalOperator::UdbRecordingPhysicalOperator(std::optional<std::string> traceName)
-    : traceName(std::move(traceName))
+UdbRecordingPhysicalOperator::UdbRecordingPhysicalOperator(std::optional<std::string> traceName) : traceName(std::move(traceName))
 {
 }
 

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -1,0 +1,168 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <UdbRecordingPhysicalOperator.hpp>
+
+#include <cstdlib>
+#include <fcntl.h>
+#include <optional>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <Nautilus/Interface/Record.hpp>
+#include <Nautilus/Interface/RecordBuffer.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <CompilationContext.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalOperator.hpp>
+#include <PipelineExecutionContext.hpp>
+#include <function.hpp>
+
+namespace NES
+{
+
+namespace
+{
+
+/// Spawns udb attached to the current NES PID. udb detaches itself after attaching so no reaping needed.
+///
+/// Prerequisites:
+///   1. UDB_BINARY_PATH must point to the udb executable, e.g. via direnv:
+///        export UDB_BINARY_PATH=/path/to/udb
+///   2. ptrace_scope must be 0 on Linux, otherwise user-space processes are not allowed to attach.
+///      Check with: cat /proc/sys/kernel/yama/ptrace_scope
+///      Allow for the current session with: echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+void spawnUdbProxy(const char* traceName)
+{
+    const char* udbBin = std::getenv("UDB_BINARY_PATH");
+    if (udbBin == nullptr)
+    {
+        NES_WARNING("UDB_BINARY_PATH is not set — skipping udb recording");
+        return;
+    }
+
+    /// Build strings before fork() — malloc is not async-signal-safe in the child.
+    char pidBuf[32];
+    ::snprintf(pidBuf, sizeof(pidBuf), "%d", static_cast<int>(::getpid()));
+
+    char traceFileBuf[512];
+    if (traceName != nullptr)
+        ::snprintf(traceFileBuf, sizeof(traceFileBuf), "%s.undo", traceName);
+
+    NES_DEBUG("UdbRecordingPhysicalOperator: spawning udb (binary={}, pid={})", udbBin, pidBuf);
+
+    /// Pipe with O_CLOEXEC on the write end: exec closes it automatically on success.
+    /// If execlp fails the child writes a byte so the parent can log the error safely.
+    int pipeFd[2];
+    if (::pipe2(pipeFd, O_CLOEXEC) != 0)
+    {
+        NES_ERROR("UdbRecordingPhysicalOperator: pipe2 failed");
+        return;
+    }
+
+    const pid_t child = ::fork();
+    if (child == 0)
+    {
+        /// Child: write end is O_CLOEXEC — exec closes it. On failure write a byte so parent detects it.
+        if (traceName != nullptr)
+            ::execlp(udbBin, udbBin, "--pid", pidBuf, "--recording-file", traceFileBuf, nullptr);
+        else
+            ::execlp(udbBin, udbBin, "--pid", pidBuf, nullptr);
+
+        /// execlp only returns on failure — only async-signal-safe calls allowed here.
+        const char errByte = 1;
+        static_cast<void>(::write(pipeFd[1], &errByte, 1));
+        ::_exit(127);
+    }
+
+    /// Parent: close write end, then check if child signalled failure.
+    ::close(pipeFd[1]);
+
+    if (child < 0)
+    {
+        NES_ERROR("UdbRecordingPhysicalOperator: fork failed");
+        ::close(pipeFd[0]);
+        return;
+    }
+
+    char result = 0;
+    if (::read(pipeFd[0], &result, 1) == 1)
+    {
+        NES_ERROR("UdbRecordingPhysicalOperator: execlp failed for binary '{}'", udbBin);
+        ::waitpid(child, nullptr, 0);
+    }
+    ::close(pipeFd[0]);
+}
+
+}
+
+UdbRecordingPhysicalOperator::UdbRecordingPhysicalOperator(std::optional<std::string> traceName)
+    : traceName(std::move(traceName))
+{
+}
+
+void UdbRecordingPhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+{
+    if (child.has_value())
+    {
+        setupChild(executionCtx, compilationContext);
+    }
+    const char* traceNamePtr = traceName.has_value() ? traceName->c_str() : nullptr;
+    nautilus::invoke(spawnUdbProxy, nautilus::val<const char*>(traceNamePtr));
+}
+
+void UdbRecordingPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+{
+    if (child.has_value())
+    {
+        openChild(executionCtx, recordBuffer);
+    }
+}
+
+void UdbRecordingPhysicalOperator::execute(ExecutionContext& executionCtx, Record& record) const
+{
+    if (child.has_value())
+    {
+        executeChild(executionCtx, record);
+    }
+}
+
+void UdbRecordingPhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+{
+    if (child.has_value())
+    {
+        closeChild(executionCtx, recordBuffer);
+    }
+}
+
+void UdbRecordingPhysicalOperator::terminate(ExecutionContext& executionCtx) const
+{
+    if (child.has_value())
+    {
+        terminateChild(executionCtx);
+    }
+}
+
+std::optional<PhysicalOperator> UdbRecordingPhysicalOperator::getChild() const
+{
+    return child;
+}
+
+void UdbRecordingPhysicalOperator::setChild(PhysicalOperator newChild)
+{
+    child = std::move(newChild);
+}
+
+}

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -14,12 +14,18 @@
 
 #include <UdbRecordingPhysicalOperator.hpp>
 
+#include <array>
+#include <cerrno>
+#include <cstdint>
 #include <cstdlib>
 #include <optional>
 #include <string>
+#include <utility>
 #include <fcntl.h>
 #include <unistd.h>
+#include <linux/prctl.h>
 #include <sys/prctl.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 
 #include <Interface/Record.hpp>
@@ -28,8 +34,6 @@
 #include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
-#include <PipelineExecutionContext.hpp>
-#include <function.hpp>
 
 namespace NES
 {
@@ -108,10 +112,14 @@ void spawnUdbProxy(const std::optional<std::string>& traceName)
 
     char result = 0;
     ssize_t nread = 0;
-    do
+    for (;;)
     {
         nread = ::read(pipeFd[0], &result, 1);
-    } while (nread < 0 && errno == EINTR); /// retry on SIGCHLD or other interrupts
+        if (nread >= 0 || errno != EINTR)
+        {
+            break;
+        }
+    } /// retry on SIGCHLD or other interrupts
 
     if (nread == 1)
     {

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -22,8 +22,8 @@
 #include <sys/prctl.h>
 #include <sys/wait.h>
 
-#include <Nautilus/Interface/Record.hpp>
-#include <Nautilus/Interface/RecordBuffer.hpp>
+#include <Interface/Record.hpp>
+#include <Interface/RecordBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -42,32 +42,27 @@ namespace
 /// Prerequisites:
 ///   1. UDB_BINARY_PATH must point to the udb executable, e.g. via direnv:
 ///        export UDB_BINARY_PATH=/path/to/udb
-///   2. ptrace_scope must be 0 on Linux, otherwise user-space processes are not allowed to attach.
-///      Check with: cat /proc/sys/kernel/yama/ptrace_scope
-///      Allow for the current session with: echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 void spawnUdbProxy(const char* traceName)
 {
-    const char* udbBin = std::getenv("UDB_BINARY_PATH");
-    if (udbBin == nullptr)
+    const char* udbBinEnv = std::getenv("UDB_BINARY_PATH");
+    if (udbBinEnv == nullptr)
     {
         NES_ERROR("UDB_BINARY_PATH is not set — skipping udb recording");
         return;
     }
+    /// Copy immediately so a concurrent setenv/unsetenv cannot invalidate the pointer.
+    const std::string udbBin = udbBinEnv;
 
     /// Build strings before fork() — malloc is not async-signal-safe in the child.
-    char pidBuf[32];
-    ::snprintf(pidBuf, sizeof(pidBuf), "%d", static_cast<int>(::getpid()));
+    const std::string pidStr = std::to_string(static_cast<int>(::getpid()));
+    const std::string traceFile = (traceName != nullptr) ? std::string(traceName) + ".undo" : std::string{};
 
-    char traceFileBuf[512];
-    if (traceName != nullptr)
-        ::snprintf(traceFileBuf, sizeof(traceFileBuf), "%s.undo", traceName);
-
-    NES_DEBUG("UdbRecordingPhysicalOperator: spawning udb (binary={}, pid={})", udbBin, pidBuf);
+    NES_DEBUG("UdbRecordingPhysicalOperator: spawning udb (binary={}, pid={})", udbBin, pidStr);
 
     /// Pipe with O_CLOEXEC on the write end: exec closes it automatically on success.
     /// If execlp fails the child writes a byte so the parent can log the error safely.
-    int pipeFd[2];
-    if (::pipe2(pipeFd, O_CLOEXEC) != 0)
+    std::array<int, 2> pipeFd{};
+    if (::pipe2(pipeFd.data(), O_CLOEXEC) != 0)
     {
         NES_ERROR("UdbRecordingPhysicalOperator: pipe2 failed");
         return;
@@ -77,15 +72,22 @@ void spawnUdbProxy(const char* traceName)
     if (child == 0)
     {
         /// Child: write end is O_CLOEXEC — exec closes it. On failure write a byte so parent detects it.
+        // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
         if (traceName != nullptr)
-            ::execl(udbBin, udbBin, "--pid", pidBuf, "--recording-file", traceFileBuf, nullptr);
+        {
+            ::execl(udbBin.c_str(), udbBin.c_str(), "--pid", pidStr.c_str(), "--recording-file", traceFile.c_str(), nullptr);
+        }
         else
-            ::execl(udbBin, udbBin, "--pid", pidBuf, nullptr);
+        {
+            ::execl(udbBin.c_str(), udbBin.c_str(), "--pid", pidStr.c_str(), nullptr);
+        }
+        // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
         /// execlp only returns on failure — only async-signal-safe calls allowed here.
         const char errByte = 1;
         static_cast<void>(::write(pipeFd[1], &errByte, 1));
-        ::_exit(127);
+        constexpr int exitExecFailed = 127;
+        std::_Exit(exitExecFailed);
     }
 
     /// Parent: close write end, then check if child signalled failure.
@@ -99,13 +101,15 @@ void spawnUdbProxy(const char* traceName)
     }
 
     /// Grant ptrace permission to exactly this child; avoids having to lower yama/ptrace_scope to 0 (c.f. man 2 prctl)
-    if (::prctl(PR_SET_PTRACER, static_cast<unsigned long>(child)) < 0)
+    if (::prctl(PR_SET_PTRACER, static_cast<int64_t>(child)) < 0) /// NOLINT(cppcoreguidelines-pro-type-vararg)
     {
         NES_ERROR("UdbRecordingPhysicalOperator: prctl(PR_SET_PTRACER) failed, errno={}", errno);
     }
 
     char result = 0;
-    if (::read(pipeFd[0], &result, 1) == 1)
+    ssize_t n;
+    do { n = ::read(pipeFd[0], &result, 1); } while (n < 0 && errno == EINTR); // retry on SIGCHLD or other interrupts
+    if (n == 1)
     {
         NES_ERROR("UdbRecordingPhysicalOperator: execlp failed for binary '{}'", udbBin);
         ::waitpid(child, nullptr, 0);
@@ -126,7 +130,7 @@ void UdbRecordingPhysicalOperator::setup(ExecutionContext& executionCtx, Compila
         setupChild(executionCtx, compilationContext);
     }
     const char* traceNamePtr = traceName.has_value() ? traceName->c_str() : nullptr;
-    nautilus::invoke(spawnUdbProxy, nautilus::val<const char*>(traceNamePtr));
+    spawnUdbProxy(traceNamePtr);
 }
 
 void UdbRecordingPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -72,7 +72,7 @@ void spawnUdbProxy(const char* traceName)
     if (child == 0)
     {
         /// Child: write end is O_CLOEXEC — exec closes it. On failure write a byte so parent detects it.
-        // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
+        /// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
         if (traceName != nullptr)
         {
             ::execl(udbBin.c_str(), udbBin.c_str(), "--pid", pidStr.c_str(), "--recording-file", traceFile.c_str(), nullptr);
@@ -81,7 +81,7 @@ void spawnUdbProxy(const char* traceName)
         {
             ::execl(udbBin.c_str(), udbBin.c_str(), "--pid", pidStr.c_str(), nullptr);
         }
-        // NOLINTEND(cppcoreguidelines-pro-type-vararg)
+        /// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
         /// execlp only returns on failure — only async-signal-safe calls allowed here.
         const char errByte = 1;
@@ -107,9 +107,13 @@ void spawnUdbProxy(const char* traceName)
     }
 
     char result = 0;
-    ssize_t n;
-    do { n = ::read(pipeFd[0], &result, 1); } while (n < 0 && errno == EINTR); // retry on SIGCHLD or other interrupts
-    if (n == 1)
+    ssize_t nread = 0;
+    do
+    {
+        nread = ::read(pipeFd[0], &result, 1);
+    } while (nread < 0 && errno == EINTR); /// retry on SIGCHLD or other interrupts
+
+    if (nread == 1)
     {
         NES_ERROR("UdbRecordingPhysicalOperator: execlp failed for binary '{}'", udbBin);
         ::waitpid(child, nullptr, 0);

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -57,14 +57,14 @@ void spawnUdbProxy(const char* traceName)
     const std::string pidStr = std::to_string(static_cast<int>(::getpid()));
     const std::string traceFile = (traceName != nullptr) ? std::string(traceName) + ".undo" : std::string{};
 
-    NES_DEBUG("UdbRecordingPhysicalOperator: spawning udb (binary={}, pid={})", udbBin, pidStr);
+    NES_DEBUG("Spawning udb (binary={}, pid={})", udbBin, pidStr);
 
     /// Pipe with O_CLOEXEC on the write end: exec closes it automatically on success.
     /// If execlp fails the child writes a byte so the parent can log the error safely.
     std::array<int, 2> pipeFd{};
     if (::pipe2(pipeFd.data(), O_CLOEXEC) != 0)
     {
-        NES_ERROR("UdbRecordingPhysicalOperator: pipe2 failed");
+        NES_ERROR("Pipe2 failed");
         return;
     }
 
@@ -95,7 +95,7 @@ void spawnUdbProxy(const char* traceName)
 
     if (child < 0)
     {
-        NES_ERROR("UdbRecordingPhysicalOperator: fork failed");
+        NES_ERROR("Fork failed");
         ::close(pipeFd[0]);
         return;
     }
@@ -103,7 +103,7 @@ void spawnUdbProxy(const char* traceName)
     /// Grant ptrace permission to exactly this child; avoids having to lower yama/ptrace_scope to 0 (c.f. man 2 prctl)
     if (::prctl(PR_SET_PTRACER, static_cast<int64_t>(child)) < 0) /// NOLINT(cppcoreguidelines-pro-type-vararg)
     {
-        NES_ERROR("UdbRecordingPhysicalOperator: prctl(PR_SET_PTRACER) failed, errno={}", errno);
+        NES_ERROR("prctl(PR_SET_PTRACER) failed, errno={}", errno);
     }
 
     char result = 0;
@@ -115,7 +115,7 @@ void spawnUdbProxy(const char* traceName)
 
     if (nread == 1)
     {
-        NES_ERROR("UdbRecordingPhysicalOperator: execlp failed for binary '{}'", udbBin);
+        NES_ERROR("execlp failed for binary '{}'", udbBin);
         ::waitpid(child, nullptr, 0);
     }
     ::close(pipeFd[0]);

--- a/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UdbRecordingPhysicalOperator.cpp
@@ -42,7 +42,7 @@ namespace
 /// Prerequisites:
 ///   1. UDB_BINARY_PATH must point to the udb executable, e.g. via direnv:
 ///        export UDB_BINARY_PATH=/path/to/udb
-void spawnUdbProxy(const char* traceName)
+void spawnUdbProxy(const std::optional<std::string>& traceName)
 {
     const char* udbBinEnv = std::getenv("UDB_BINARY_PATH");
     if (udbBinEnv == nullptr)
@@ -55,7 +55,7 @@ void spawnUdbProxy(const char* traceName)
 
     /// Build strings before fork() — malloc is not async-signal-safe in the child.
     const std::string pidStr = std::to_string(static_cast<int>(::getpid()));
-    const std::string traceFile = (traceName != nullptr) ? std::string(traceName) + ".undo" : std::string{};
+    const std::string traceFile = traceName.has_value() ? *traceName + ".undo" : std::string{};
 
     NES_DEBUG("Spawning udb (binary={}, pid={})", udbBin, pidStr);
 
@@ -73,7 +73,7 @@ void spawnUdbProxy(const char* traceName)
     {
         /// Child: write end is O_CLOEXEC — exec closes it. On failure write a byte so parent detects it.
         /// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
-        if (traceName != nullptr)
+        if (traceName.has_value())
         {
             ::execl(udbBin.c_str(), udbBin.c_str(), "--pid", pidStr.c_str(), "--recording-file", traceFile.c_str(), nullptr);
         }
@@ -133,8 +133,7 @@ void UdbRecordingPhysicalOperator::setup(ExecutionContext& executionCtx, Compila
     {
         setupChild(executionCtx, compilationContext);
     }
-    const char* traceNamePtr = traceName.has_value() ? traceName->c_str() : nullptr;
-    spawnUdbProxy(traceNamePtr);
+    spawnUdbProxy(traceName);
 }
 
 void UdbRecordingPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const

--- a/nes-query-compiler/include/LoweringRules/LowerToPhysical/LowerToPhysicalUdbRecording.hpp
+++ b/nes-query-compiler/include/LoweringRules/LowerToPhysical/LowerToPhysicalUdbRecording.hpp
@@ -1,0 +1,28 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <LoweringRules/AbstractLoweringRule.hpp>
+#include <Operators/LogicalOperator.hpp>
+
+namespace NES
+{
+
+struct LowerToPhysicalUdbRecording : AbstractLoweringRule
+{
+    LoweringRuleResultSubgraph apply(LogicalOperator logicalOperator) override;
+};
+
+}

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/CMakeLists.txt
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/CMakeLists.txt
@@ -22,3 +22,4 @@ add_plugin(IngestionTimeWatermarkAssigner LoweringRule LowerToPhysicalIngestionT
 add_plugin(EventTimeWatermarkAssigner LoweringRule LowerToPhysicalEventTimeWatermarkAssigner.cpp)
 add_plugin(InferModel LoweringRule LowerToPhysicalInferModel.cpp)
 add_plugin(ReplayStore LoweringRule LowerToPhysicalReplayStore.cpp)
+add_plugin(UdbRecording LoweringRule LowerToPhysicalUdbRecording.cpp)

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalUdbRecording.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalUdbRecording.cpp
@@ -1,0 +1,61 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <LoweringRules/LowerToPhysical/LowerToPhysicalUdbRecording.hpp>
+
+#include <memory>
+
+#include <LoweringRules/AbstractLoweringRule.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/UdbRecordingLogicalOperator.hpp>
+#include <Traits/MemoryLayoutTypeTrait.hpp>
+#include <ErrorHandling.hpp>
+#include <LoweringRuleRegistry.hpp>
+#include <PhysicalOperator.hpp>
+#include <UdbRecordingPhysicalOperator.hpp>
+
+namespace NES
+{
+
+LoweringRuleResultSubgraph LowerToPhysicalUdbRecording::apply(LogicalOperator logicalOperator)
+{
+    PRECONDITION(logicalOperator.tryGetAs<UdbRecordingLogicalOperator>(), "Expected a UdbRecordingLogicalOperator");
+    const auto udbOp = logicalOperator.getAs<UdbRecordingLogicalOperator>();
+
+    const auto inputSchema = logicalOperator.getInputSchemas()[0];
+    const auto outputSchema = logicalOperator.getOutputSchema();
+    const auto memoryLayoutTypeTrait = logicalOperator.getTraitSet().tryGet<MemoryLayoutTypeTrait>();
+    PRECONDITION(memoryLayoutTypeTrait.has_value(), "Expected a memory layout type trait");
+    const auto memoryLayoutType = memoryLayoutTypeTrait.value()->memoryLayout;
+
+    auto physicalOperator = UdbRecordingPhysicalOperator(udbOp->getTraceName());
+    auto wrapper = std::make_shared<PhysicalOperatorWrapper>(
+        physicalOperator,
+        inputSchema,
+        outputSchema,
+        memoryLayoutType,
+        memoryLayoutType,
+        PhysicalOperatorWrapper::PipelineLocation::INTERMEDIATE);
+
+    const std::vector leafs{wrapper};
+    return {.root = wrapper, .leafs = leafs};
+}
+
+std::unique_ptr<AbstractLoweringRule>
+LoweringRuleGeneratedRegistrar::RegisterUdbRecordingLoweringRule(LoweringRuleRegistryArguments) /// NOLINT
+{
+    return std::make_unique<LowerToPhysicalUdbRecording>();
+}
+
+}

--- a/nes-sources/src/SourceProvider.cpp
+++ b/nes-sources/src/SourceProvider.cpp
@@ -49,10 +49,7 @@ SourceProvider::lower(OriginId originId, BackpressureListener backpressureListen
             ? sourceDescriptor.getFromConfig(SourceDescriptor::MAX_INFLIGHT_BUFFERS)
             : defaultMaxInflightBuffers;
         SourceRuntimeConfiguration runtimeConfig{maxInflightBuffers};
-        NES_DEBUG(
-            "SourceProvider: lowering source type={} originId={}",
-            sourceDescriptor.getSourceType(),
-            originId.getRawValue());
+        NES_DEBUG("SourceProvider: lowering source type={} originId={}", sourceDescriptor.getSourceType(), originId.getRawValue());
         if (sourceDescriptor.getSourceType() == "Replay")
         {
             const auto* replaySource = dynamic_cast<ReplaySource*>(source.value().get());

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -131,7 +131,7 @@ queryPrimary
     | '(' query ')'                                                         #subquery
     ;
 /// new layout to be closer to traditional SQL
-querySpecification: selectClause fromClause whereClause? windowedAggregationClause? havingClause? sinkClause? timeTravelClause?;
+querySpecification: selectClause fromClause whereClause? windowedAggregationClause? havingClause? sinkClause? timeTravelClause? udbClause?;
 
 
 fromClause: FROM relation (',' relation)*;
@@ -334,6 +334,8 @@ inlineSink
 
 timeTravelClause: TIME_TRAVEL_STORE storeName=identifier;
 
+udbClause: TIME_TRAVEL_UDB udbTraceName=identifier?;
+
 nullNotnull
     : NOT? NULLTOKEN
     ;
@@ -519,6 +521,7 @@ AT_LEAST_ONCE : 'AT_LEAST_ONCE';
 JSON: 'JSON';
 TEXT: 'TEXT';
 TIME_TRAVEL_STORE : 'TIME_TRAVEL_STORE';
+TIME_TRAVEL_UDB : 'TIME_TRAVEL_UDB';
 EXPLAIN: 'EXPLAIN' | 'explain';
 MODEL: 'MODEL';
 MODELS: 'MODELS';

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
@@ -81,9 +81,9 @@ public:
     std::vector<std::string> joinSourceRenames;
     JoinLogicalOperator::JoinType joinType = JoinLogicalOperator::JoinType::INNER_JOIN;
     std::optional<std::unordered_map<std::string, std::string>> storeOptions;
-    
-    // UDB specific variables
-    bool hasUdbClause = false;
+
+    /// UDB specific variables
+    bool hasUdbClause{false};
     std::optional<std::string> udbTraceName;
 
     /// Utility variables to keep state between enter/exit parser function calls.

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
@@ -81,6 +81,10 @@ public:
     std::vector<std::string> joinSourceRenames;
     JoinLogicalOperator::JoinType joinType = JoinLogicalOperator::JoinType::INNER_JOIN;
     std::optional<std::unordered_map<std::string, std::string>> storeOptions;
+    
+    // UDB specific variables
+    bool hasUdbClause = false;
+    std::optional<std::string> udbTraceName;
 
     /// Utility variables to keep state between enter/exit parser function calls.
     size_t opBoolean{}; ///anonymous token enum in AntlrSQLLexer.h

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
@@ -85,6 +85,7 @@ public:
     void exitThresholdMinSizeParameter(AntlrSQLParser::ThresholdMinSizeParameterContext* context) override;
     void enterInlineSource(AntlrSQLParser::InlineSourceContext* context) override;
     void enterTimeTravelClause(AntlrSQLParser::TimeTravelClauseContext* context) override;
+    void enterUdbClause(AntlrSQLParser::UdbClauseContext* context) override;
 };
 
 }

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -1131,6 +1131,7 @@ void AntlrSQLQueryPlanCreator::enterTimeTravelClause(AntlrSQLParser::TimeTravelC
 void AntlrSQLQueryPlanCreator::enterUdbClause(AntlrSQLParser::UdbClauseContext* context)
 {
     helpers.top().hasUdbClause = true;
+    /// if no trace name is provided UDB auto generates one
     if (context->udbTraceName != nullptr)
         helpers.top().udbTraceName = context->udbTraceName->getText();
 }

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -52,6 +52,7 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Functions/LogicalFunctionProvider.hpp>
 #include <Operators/ReplayStoreLogicalOperator.hpp>
+#include <Operators/UdbRecordingLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp>
@@ -545,6 +546,11 @@ void AntlrSQLQueryPlanCreator::exitPrimaryQuery(AntlrSQLParser::PrimaryQueryCont
         auto opts = *helpers.top().storeOptions;
         const auto cfg = ReplayStoreLogicalOperator::validateAndFormatConfig(std::move(opts));
         queryPlan = LogicalPlanBuilder::addReplayStore(cfg, queryPlan);
+    }
+    /// inject UDB recording operator into the plan if TIME_TRAVEL_UDB was provided
+    if (helpers.top().hasUdbClause)
+    {
+        queryPlan = LogicalPlanBuilder::addUdbRecording(helpers.top().udbTraceName, queryPlan);
     }
     helpers.pop();
     if (helpers.empty())
@@ -1120,5 +1126,12 @@ void AntlrSQLQueryPlanCreator::enterTimeTravelClause(AntlrSQLParser::TimeTravelC
     options.emplace("store_name", storeName);
 
     helpers.top().storeOptions = std::move(options);
+}
+
+void AntlrSQLQueryPlanCreator::enterUdbClause(AntlrSQLParser::UdbClauseContext* context)
+{
+    helpers.top().hasUdbClause = true;
+    if (context->udbTraceName != nullptr)
+        helpers.top().udbTraceName = context->udbTraceName->getText();
 }
 }

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -418,8 +418,7 @@ void AntlrSQLQueryPlanCreator::enterIdentifier(AntlrSQLParser::IdentifierContext
     }
     else if (
         helpers.top().isFrom and not helpers.top().isJoinRelation and not helpers.top().isModelInference
-        and AntlrSQLParser::RuleErrorCapturingIdentifier == parentRuleIndex
-        and helpers.top().getSource().empty())
+        and AntlrSQLParser::RuleErrorCapturingIdentifier == parentRuleIndex and helpers.top().getSource().empty())
     {
         /// get main source name
         helpers.top().setSource(bindIdentifier(context));

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -52,7 +52,6 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Functions/LogicalFunctionProvider.hpp>
 #include <Operators/ReplayStoreLogicalOperator.hpp>
-#include <Operators/UdbRecordingLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp>
@@ -1132,6 +1131,8 @@ void AntlrSQLQueryPlanCreator::enterUdbClause(AntlrSQLParser::UdbClauseContext* 
     helpers.top().hasUdbClause = true;
     /// if no trace name is provided UDB auto generates one
     if (context->udbTraceName != nullptr)
+    {
         helpers.top().udbTraceName = context->udbTraceName->getText();
+    }
 }
 }

--- a/nes-systests/operator/replay/UdbRecording_TimeTravel.test
+++ b/nes-systests/operator/replay/UdbRecording_TimeTravel.test
@@ -1,0 +1,20 @@
+# name: operator/replay/UdbRecording_TimeTravel.test
+# description: Run a query with TIME_TRAVEL_UDB and verify the query produces the expected output
+# groups: [UdbRecording]
+
+CREATE LOGICAL SOURCE stream(id UINT64, value UINT64, timestamp UINT64);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+1,1,1000
+2,1,1001
+3,1,1002
+4,2,2000
+
+CREATE SINK sink(stream.id UINT64, stream.value UINT64, stream.timestamp UINT64) TYPE File;
+
+SELECT id, value, timestamp FROM stream INTO sink TIME_TRAVEL_UDB recording;
+----
+1,1,1000
+2,1,1001
+3,1,1002
+4,2,2000

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -872,8 +872,8 @@ struct SystestBinder::Impl
             auto logicalSource = sourceCatalog->addLogicalSource(storeName, storeSchema);
             INVARIANT(logicalSource.has_value(), "Failed to register store '{}' as a logical source", storeName);
 
-            auto physicalSource
-                = sourceCatalog->addPhysicalSource(*logicalSource, "Replay", Host("localhost"), {{"store_name", storeName}}, {{"type", "CSV"}});
+            auto physicalSource = sourceCatalog->addPhysicalSource(
+                *logicalSource, "Replay", Host("localhost"), {{"store_name", storeName}}, {{"type", "CSV"}});
             INVARIANT(physicalSource.has_value(), "Failed to register Replay physical source for store '{}'", storeName);
 
             /// Create and initialize the store in the StoreRegistry so it is ready for writes
@@ -917,7 +917,8 @@ struct SystestBinder::Impl
                     }
                     std::unordered_map<std::string, std::string> sourceConfig{{"store_name", sourceName}};
                     std::unordered_map<std::string, std::string> parserConfig{{"type", "NATIVE"}};
-                    const InlineSourceLogicalOperator inlineOp{WeakLogicalOperator{}, "Replay", schema, std::move(sourceConfig), std::move(parserConfig)};
+                    const InlineSourceLogicalOperator inlineOp{
+                        WeakLogicalOperator{}, "Replay", schema, std::move(sourceConfig), std::move(parserConfig)};
                     return inlineOp.withChildren(newChildren);
                 }
             }

--- a/scripts/check_preamble.py
+++ b/scripts/check_preamble.py
@@ -52,6 +52,7 @@ COLOR_RESET = "\033[0m"
 INGORED_ENDINGS = {
     "clang-format",
     "clang-tidy",
+    "clangd",
     "csv",
     "disabled",
     "dockerfile",


### PR DESCRIPTION
This PR closes #23. It adds initial support for recording a running NES instance via UDB. A new SQL clause TIME_TRAVEL_UDB [trace_name] triggers UDB to attach to the NES worker process and begin recording.
  Recording stops when NES terminates.

  SQL Parser (AntlrSQL.g4, AntlrSQLQueryPlanCreator):
  - Added udbClause grammar rule and TIME_TRAVEL_UDB keyword
  - The optional trace name is passed through to the logical operator; if omitted, UDB auto-generates one

  Logical Operators (UdbRecordingLogicalOperator, LogicalPlanBuilder):
  - Introduces UdbRecordingLogicalOperator as a passthrough operator carrying the optional trace name through the logical plan
  - Registered as a plugin under the name UdbRecording
  - LogicalPlanBuilder::addUdbRecording promotes it to root via promoteOperatorToRoot

  Physical Operators (UdbRecordingPhysicalOperator, LowerToPhysicalUdbRecording):
  - UdbRecordingPhysicalOperator spawns UDB during pipeline setup attached to the NES worker PID
  - UDB binary path is read from UDB_BINARY_PATH
  - prctl(PR_SET_PTRACER, child) is called after fork so UDB can ptrace NES without requiring ptrace_scope=0 system-wide
  - An O_CLOEXEC pipe relays exec failure to the parent; read() retries on EINTR (interrupted syscall) to prevent a concurrent SIGCHLD from masking a failed execl

  Systests (UdbR ecording_TimeTravel.test):
  - Verifies that a query with TIME_TRAVEL_UDB produces correct output; does not affect result tuples
